### PR TITLE
Make app layer compatible with nodejs 12.x

### DIFF
--- a/README-SAR.md
+++ b/README-SAR.md
@@ -6,7 +6,7 @@ and support for jpeg, gif, png, tiff and webm formats.
 
 This application provides a single output, `LayerVersion`, which points to a
 Lambda Layer ARN you can use with Lambda runtimes based on Amazon Linux 2 (such
-as the `nodejs10.x` runtime).
+as the `nodejs10.x` or `nodejs12.x` runtime).
 
 For an example of how to use the layer, check out 
 https://github.com/serverlesspub/imagemagick-aws-lambda-2/tree/master/example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ImageMagick for AWS Lambda
 
-Scripts to compile ImageMagick utilities for AWS Lambda instances powered by Amazon Linux 2.x, such as the `nodejs10.x` runtime, and the updated 2018.03 Amazon Linux 1 runtimes. 
+Scripts to compile ImageMagick utilities for AWS Lambda instances powered by Amazon Linux 2.x, such as the `nodejs10.x` or `nodejs12.x` runtime, and the updated 2018.03 Amazon Linux 1 runtimes. 
 
 Amazon Linux 2 instances for Lambda no longer contain system utilities, so `convert`, `mogrify` and `identify` from the [ImageMagick](https://imagemagick.org) package are no longer available. 
 

--- a/template.yaml
+++ b/template.yaml
@@ -16,6 +16,7 @@ Resources:
       ContentUri: build/layer.zip
       CompatibleRuntimes:
         - nodejs10.x
+        - nodejs12.x
       LicenseInfo: https://imagemagick.org/script/license.php
       RetentionPolicy: Retain
 


### PR DESCRIPTION
As AWS released support for Nodejs 12.x, both on their Linux 2 instance. Should work the same.