### PR TITLE
makefile: docker command overridable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGET ?=/opt/
 MOUNTS = -v $(PROJECT_ROOT):/var/task \
 	-v $(PROJECT_ROOT)result:$(TARGET)
 
-DOCKER = docker run -it --rm -w=/var/task/build
+DOCKER ?= docker run -it --rm -w=/var/task/build
 build result: 
 	mkdir $@
 


### PR DESCRIPTION
make the docker command overridable so that, for example, `-it` can be removed