### PR TITLE
adding freetype support and updating version of ImageMagick

### DIFF
--- a/Makefile_ImageMagick
+++ b/Makefile_ImageMagick
@@ -1,10 +1,11 @@
 LIBPNG_VERSION ?= 1.6.37
-LIBJPG_VERSION ?= 9c
+LIBJPG_VERSION ?= 9d
 OPENJP2_VERSION ?= 2.3.1
 LIBTIFF_VERSION ?= 4.0.9
 BZIP2_VERSION ?= 1.0.6
 LIBWEBP_VERSION ?= 0.6.1
-IMAGEMAGICK_VERSION ?= 7.0.8-45
+LIBFREETYPE_VERSION ?= 2.10.1
+IMAGEMAGICK_VERSION ?= 7.0.10-16
 
 TARGET_DIR ?= /opt/
 PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -34,7 +35,6 @@ $(CACHE_DIR)/lib/libjpeg.a: $(LIBJPG_SOURCE)
 	$(CONFIGURE)	 
 	make
 	make install
-
 
 ## libpng
 
@@ -113,6 +113,19 @@ $(CACHE_DIR)/lib/libopenjp2.a: $(OPENJP2_SOURCE) $(CACHE_DIR)/lib/libpng.a $(CAC
 	make clean
 	make install
 
+## libfreetype
+
+LIBFREETYPE_SOURCE=freetype-$(LIBFREETYPE_VERSION).tar.xz
+
+$(LIBFREETYPE_SOURCE):
+	curl -LO http://download.savannah.gnu.org/releases/freetype/$(LIBFREETYPE_SOURCE)
+
+$(CACHE_DIR)/lib/libfreetype.a: $(LIBFREETYPE_SOURCE)
+	tar xf $<
+	cd freetype*
+	$(CONFIGURE)
+	make
+	make install
 
 ## ImageMagick
 
@@ -127,7 +140,8 @@ LIBS:=$(CACHE_DIR)/lib/libjpeg.a \
 	$(CACHE_DIR)/lib/libopenjp2.a \
 	$(CACHE_DIR)/lib/libtiff.a \
 	$(CACHE_DIR)/lib/libbz2.a \
-	$(CACHE_DIR)/lib/libwebp.a
+	$(CACHE_DIR)/lib/libwebp.a \
+	$(CACHE_DIR)/lib/libfreetype.a
 
 $(TARGET_DIR)/bin/identify: $(IMAGE_MAGICK_SOURCE) $(LIBS)
 	tar xf $<

--- a/README-SAR.md
+++ b/README-SAR.md
@@ -2,7 +2,7 @@
 
 Static build of ImageMagick for Amazon Linux 2, packaged as a Lambda layer. 
 Bundles ImageMagick 7.0.8-45, including convert, mogrify and identify tools
-and support for jpeg, gif, png, tiff and webm formats.
+and support for jpeg, gif, png, tiff and webm formats and freetype font engine.
 
 This application provides a single output, `LayerVersion`, which points to a
 Lambda Layer ARN you can use with Lambda runtimes based on Amazon Linux 2 (such

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ These libraries are currently bundled:
 * libjpeg
 * openjpeg2
 * libwebp
+* libfreetype
 
 ## Deploying to AWS as a layer
 

--- a/template.yaml
+++ b/template.yaml
@@ -3,7 +3,8 @@ Transform: AWS::Serverless-2016-10-31
 Description: >
   Static build of ImageMagick for Amazon Linux 2,
   including convert, mogrify and identify tools
-  and support for jpeg, gif, png, tiff and webm formats.
+  and support for jpeg, gif, png, tiff and webm formats
+  and freetype font engine.
 
   Check out https://github.com/serverlesspub/imagemagick-aws-lambda-2
   for more information.
@@ -34,7 +35,8 @@ Metadata:
       packaged as a Lambda layer. Bundles ImageMagick 7.0.8-45.
 
       Including convert, mogrify and identify tools
-      and support for jpeg, gif, png, tiff and webm formats.
+      and support for jpeg, gif, png, tiff and webm formats
+      and freetype font engine.
     Author: Gojko Adzic
     SpdxLicenseId: ImageMagick
     LicenseUrl: LICENSE.txt


### PR DESCRIPTION
I think that it may be useful to achieve freetype engine support when dealing with fonts in images.
It is worthy since the library compile statically easily as libpng and libjpg and it does slightly increase the final archive.

I took the chance to update also the ImageMagick and libjpg version.
I tested and it compile smootly.