### PR TITLE
Add support for Java 11 runtime

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -18,6 +18,7 @@ Resources:
         - nodejs10.x
         - nodejs12.x
         - python3.8
+        - java11
       LicenseInfo: https://imagemagick.org/script/license.php
       RetentionPolicy: Retain
 


### PR DESCRIPTION
A little change just to be able to list this layer in the compatible list of Java 11 lambda:

![image](https://user-images.githubusercontent.com/291015/104461448-1b7fa800-558e-11eb-9335-f4268cd2a2bd.png)
