### PR TITLE
Add ruby2.7 to supported runtimes

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -18,6 +18,7 @@ Resources:
         - nodejs10.x
         - nodejs12.x
         - python3.8
+        - ruby2.7
       LicenseInfo: https://imagemagick.org/script/license.php
       RetentionPolicy: Retain
 


### PR DESCRIPTION
I have built and deployed this with ruby2.7 runtime. It's working so far.